### PR TITLE
fixed windows build failing to get dependencies

### DIFF
--- a/irida-uploader.cfg
+++ b/irida-uploader.cfg
@@ -19,7 +19,11 @@ packages = rauth
 	Validation
 	github3
 	uritemplate
+	urllib3
 	GUI
+	chardet
+	certifi
+	idna
 
 files =	irida-uploader.cfg
 


### PR DESCRIPTION
`urllib3` and its dependencies (`chardet`, `certifi`, and `idna`) were not being picked up by `pynsist` when building the windows installer. Specifying them directly in the `.cfg` file fixes this issue.